### PR TITLE
Added option to specify browser based on application that opens the link

### DIFF
--- a/App/BrowserService.cs
+++ b/App/BrowserService.cs
@@ -38,7 +38,7 @@ public class BrowserService
 
       (string path, string args) = Executable.GetPathAndArgs(pref.Browser.Location);
 
-      Process.Start(path, $"{args} {uri}");
+      Process.Start(path, $"{args} {uri.OriginalString}");
     }
     catch (Exception e)
     {

--- a/App/BrowserService.cs
+++ b/App/BrowserService.cs
@@ -11,17 +11,29 @@ public class BrowserService
     _config = config;
   }
 
-  public void Launch(string url)
+  public void Launch(string url, string windowTitle)
   {
     try
     {
-      IEnumerable<UrlPreference> prefs = _config.GetUrlPreferences();
+        IEnumerable<UrlPreference> urlPreferences = _config.GetUrlPreferences("urls");
+        IEnumerable<UrlPreference> sourcePreferences = _config.GetUrlPreferences("sources");
       Uri uri = UriFactory.Get(url);
 
-      if (!prefs.TryGetPreference(uri, out UrlPreference pref))
+      UrlPreference pref = null;
+      if (urlPreferences.TryGetPreference(uri, out UrlPreference urlPref))
       {
-        Log.Write($"Unable to find a browser matching {url}.");
-        return;
+          pref = urlPref;
+      }
+
+      if (sourcePreferences.TryGetPreference(windowTitle, out UrlPreference sourcePref))
+      {
+          pref = sourcePref;
+      }
+
+      if (pref == null)
+      {
+          Log.Write($"Unable to find a browser matching {url}.");
+          return;
       }
 
       (string path, string args) = Executable.GetPathAndArgs(pref.Browser.Location);

--- a/App/ConfigService.cs
+++ b/App/ConfigService.cs
@@ -2,7 +2,7 @@
 
 public interface IConfigService
 {
-  IEnumerable<UrlPreference> GetUrlPreferences();
+  IEnumerable<UrlPreference> GetUrlPreferences(string configType);
 }
 
 public class ConfigService : IConfigService
@@ -12,7 +12,7 @@ public class ConfigService : IConfigService
   /// </summary>
   public string ConfigPath = Path.Combine(Path.GetDirectoryName(App.ExePath)!, "config.ini");
 
-  public IEnumerable<UrlPreference> GetUrlPreferences()
+  public IEnumerable<UrlPreference> GetUrlPreferences(string configType)
   {
     if (!File.Exists(ConfigPath))
       throw new InvalidOperationException($"The config file was not found: {ConfigPath}");
@@ -36,11 +36,13 @@ public class ConfigService : IConfigService
     }
 
     // Read the url preferences
-    var urls = GetConfig(configLines, "urls")
+    var urls = GetConfig(configLines, configType)
       .Select(SplitConfig)
       .Select(kvp => new UrlPreference { UrlPattern = kvp.Key, Browser = browsers[kvp.Value] })
-      .Union(new[] { new UrlPreference { UrlPattern = "*", Browser = browsers.FirstOrDefault().Value } }) // Add a catch-all that uses the first browser
       .Where(up => up.Browser != null);
+
+    if (configType == "sources")
+        urls = urls.Union(new[] { new UrlPreference { UrlPattern = "*", Browser = browsers.FirstOrDefault().Value } }); // Add a catch-all that uses the first browser
 
     return urls;
   }

--- a/App/UrlPreferenceExtensions.cs
+++ b/App/UrlPreferenceExtensions.cs
@@ -41,4 +41,39 @@ public static class UrlPreferenceExtensions
       return (domain, pattern);
     }
   }
+
+  public static bool TryGetPreference(this IEnumerable<UrlPreference> prefs, string windowTitle, out UrlPreference pref)
+  {
+    pref = prefs.FirstOrDefault(pref =>
+    {
+      (string domain, string pattern) = pref.GetDomainAndPattern(windowTitle);
+      return Regex.IsMatch(domain, pattern);
+    })!;
+
+    return pref != null;
+  }
+    
+  public static (string, string) GetDomainAndPattern(this UrlPreference pref, string windowTitle)
+  {
+    string urlPattern = pref.UrlPattern;
+  
+    if (urlPattern.StartsWith("/") && urlPattern.EndsWith("/"))
+    {
+      // The window title from the INI file is a regex
+      string pattern = urlPattern.Substring(1, urlPattern.Length - 2);
+
+      return (windowTitle, pattern);
+    }
+
+    {
+      // We're only checking the window title.
+      // Escape the input for regex; the only special character we support is a *
+      var regex = Regex.Escape(urlPattern);
+
+      // Unescape * as a wildcard.
+      string pattern = $"^{regex.Replace("\\*", ".*")}$";
+
+      return (windowTitle, pattern);
+    }
+  }
 }

--- a/App/config.ini
+++ b/App/config.ini
@@ -17,4 +17,4 @@ test2.test.com = chrome
 
 [sources]
 * - Notepad = ff
-Slack | Test = crome
+Slack | Test = chrome

--- a/App/config.ini
+++ b/App/config.ini
@@ -14,3 +14,7 @@ edge = C:\Program Files (x86)\Microsoft\Edge\Application\msedge.exe
 test2.test.com = chrome
 ; Default case. Added automatically
 ; * = whatever
+
+[sources]
+* - Notepad = ff
+Slack | Test = crome

--- a/README.md
+++ b/README.md
@@ -71,6 +71,14 @@ edge = C:\Program Files (x86)\Microsoft\Edge\Application\msedge.exe
 google.com = chrome
 visualstudio.com = edge
 mozilla.org = ff
+
+; Source preferences.
+; Only * is treated as a special character (wildcard).
+; Matches on window title of application used to open link.
+; Applied only if no url preference match is found.
+[sources]
+* - Notepad = ff
+Slack | Test = crome
 ; Default case. Added automatically
 ; * = whatever
 ```
@@ -102,3 +110,7 @@ There are two ways to specify an Url. You can use simple wildcards or full regul
 - Full regular expressions are specified by wrapping it in /'s.
 - The domain _and_ path are used in the Url comparison.
 - The regular expression syntax is based on the Microsoft .NET implementation.
+
+### Sources
+
+Wildcares and full regular expressions may also be used to match source window titles.


### PR DESCRIPTION
I wanted a way to ensure all links opened from my work email (Outlook) and chat (Slack) would be routed to the Chrome user profile I use for work even if they do not match a pre-determined URL. I was able to capture the calling application's window title and use that as a secondary match if no URL match was found.