### PR TITLE
ConfigService: Fix missing default case for [urls] section

### DIFF
--- a/App/ConfigService.cs
+++ b/App/ConfigService.cs
@@ -47,7 +47,7 @@ public class ConfigService : IConfigService
       .Select(kvp => new UrlPreference { UrlPattern = kvp.Key, Browser = browsers[kvp.Value] })
       .Where(up => up.Browser != null);
 
-    if (configType == "browsers")
+    if (configType == "urls")
       urls = urls.Union(new[] { new UrlPreference { UrlPattern = "*", Browser = browsers.FirstOrDefault().Value } }); // Add a catch-all that uses the first browser
 
     return urls;


### PR DESCRIPTION
Recent versions no longer have the default rule that's described in the `config.ini` example. This seems like an accident introduced with the new `[sources]` feature. `GetUrlPreferences()` is only ever called with the `"urls"` and `"sources"` strings.